### PR TITLE
Added missing dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ click==8.0.1
 colorama==0.4.4
 constantly==15.1.0
 Flask==2.0.1
+wheel==0.36.2
 gcloud==0.18.3
 googleapis-common-protos==1.53.0
 gunicorn==20.1.0


### PR DESCRIPTION
Added missing wheel dependency, wheel, which was required by oauth2client, gcloud, and jws.